### PR TITLE
Don't use default app_offset of 0x10000 in exec_run and _update_memory_map

### DIFF
--- a/debug_adapter/debug_adapter.py
+++ b/debug_adapter/debug_adapter.py
@@ -700,9 +700,9 @@ class DebugAdapter:
             self.pause()
         if not self.args.postmortem:
             if self.args.cmdfile:  # if a custom startup file specified, execute only it
-                self._gdb.exec_run(only_startup=True, startup_tmo=0)
+                self._gdb.exec_run(off=self.args.app_flash_off, only_startup=True, startup_tmo=0)
             else:
-                self._gdb.exec_run(start_func="app_main")
+                self._gdb.exec_run(off=self.args.app_flash_off, start_func="app_main")
             if start:
                 self._gdb.wait_target_state(dbg.TARGET_STATE_STOPPED, 10)
 

--- a/debug_adapter/debug_backend/debug_backend/hw_specific/esp.py
+++ b/debug_adapter/debug_backend/debug_backend/hw_specific/esp.py
@@ -111,7 +111,7 @@ class GdbEspXtensa(GdbXtensa):
                                            extended_remote_mode=extended_remote_mode, gdb_log_file=gdb_log_file,
                                            log_level=log_level, log_stream_handler=log_stream_handler,
                                            log_file_handler=log_file_handler)
-        self.app_flash_offset = 0x10000  # default for for ESP xtensa chips
+        # self.app_flash_offset = 0x10000  # default for for ESP xtensa chips
         self.prog_startup_cmdfile = os.path.join(DEFAULT_GDB_INIT_SCRIPT_DIR, "esp_init.gdb")
 
     def target_program(self, file_name, off, actions='verify', tmo=30):
@@ -129,12 +129,12 @@ class GdbEspXtensa(GdbXtensa):
         """
         self.monitor_run('program_esp %s %s 0x%x' % (fixup_path(file_name), actions, int(off)), tmo)
 
-    def _update_memory_map(self):
-        self.monitor_run('esp appimage_offset 0x%x' % self.app_flash_offset, 5)
+    def _update_memory_map(self, off):
+        self.monitor_run('esp appimage_offset 0x%x' % off, 5)
         self.disconnect()
         self.connect()
 
-    def exec_run(self, start_func='app_main', startup_tmo=5, only_startup=False):
+    def exec_run(self, off, start_func='app_main', startup_tmo=5, only_startup=False):
         """
         Implements logic of `run` and `start` commands. Executes a startup command file in the beginning if it specified
 
@@ -154,7 +154,7 @@ class GdbEspXtensa(GdbXtensa):
         else:
             self.target_reset()
         self.wait_target_state(TARGET_STATE_STOPPED, 10)
-        self._update_memory_map()
+        self._update_memory_map(off)
         if start_func:
             self.add_bp(start_func, tmp=True)
         self.resume()

--- a/debug_adapter/debug_backend/debug_backend/hw_specific/esp.py
+++ b/debug_adapter/debug_backend/debug_backend/hw_specific/esp.py
@@ -111,7 +111,6 @@ class GdbEspXtensa(GdbXtensa):
                                            extended_remote_mode=extended_remote_mode, gdb_log_file=gdb_log_file,
                                            log_level=log_level, log_stream_handler=log_stream_handler,
                                            log_file_handler=log_file_handler)
-        # self.app_flash_offset = 0x10000  # default for for ESP xtensa chips
         self.prog_startup_cmdfile = os.path.join(DEFAULT_GDB_INIT_SCRIPT_DIR, "esp_init.gdb")
 
     def target_program(self, file_name, off, actions='verify', tmo=30):


### PR DESCRIPTION
This allows the vscode-esp-idf-extension to work with other appOffset values such as 0x20000 for ESP-Rainmaker apps.
Here is a log of the error I get otherwise (See line #291, shows app offset of 0x10000):
[debug.log](https://github.com/espressif/esp-debug-adapter/files/5742355/debug.log)
