### PR TITLE
Fix wait target state failing

### DIFF
--- a/debug_adapter/debug_adapter.py
+++ b/debug_adapter/debug_adapter.py
@@ -928,6 +928,7 @@ class DebugAdapter:
             else:
                 self._gdb.exec_run()
             if start:
+                self._gdb.halt()
                 rsn = self._gdb.wait_target_state(dbg.TARGET_STATE_STOPPED, 10)
                 self.on_target_stopped(rsn)
 


### PR DESCRIPTION
On `DebugAdapter.run()` when calling `rsn = self._gdb.wait_target_state(dbg.TARGET_STATE_STOPPED, 10)` this call could fail if `self.args.cmdfile=False` as `self._gdb.exec_run()` forces the state `dbg.TARGET_STATE_RUNNING`. By forcing a halt we can ensure that waiting for `TARGET_STATE_STOPPED` will succeed. 